### PR TITLE
Generate config in --check mode

### DIFF
--- a/tasks/provision_dellos10.yaml
+++ b/tasks/provision_dellos10.yaml
@@ -7,6 +7,7 @@
    when: (ansible_network_os is defined and ansible_network_os == "dellos10") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os10
    register: generate_output
+   check_mode: no
 
  - name: "Provisioning vxlan configuration for dellos10"
    dellos10_config:


### PR DESCRIPTION
This ensures that when using `dellos_cfg_generate` the config files are always generated. This allows exporting the generated config without having to do the actual provisioning.